### PR TITLE
Filter out inactive channels when retrieving channel info

### DIFF
--- a/lndclient.py
+++ b/lndclient.py
@@ -16,7 +16,7 @@ class LndClient:
         self.channels = {}
 
         channels = self._run("listchannels")["channels"]
-        for c in channels:
+        for c in (c for c in channels if c["active"]):
             chan = Channel()
             chan.chan_id = c["chan_id"]
             chan.active = c["active"]


### PR DESCRIPTION
lncli getchaninfo returns an error is passed an inactive channel ID.

[lncli] rpc error: code = Unknown desc = edge not found