### PR TITLE
allow multiple client-args

### DIFF
--- a/clnclient.py
+++ b/clnclient.py
@@ -104,7 +104,7 @@ class ClnClient:
 
     def _run(self, *args):
         if self.client_args:
-            args = ["lightning-cli", self.client_args] + list(args)
+            args = ["lightning-cli"] + list(self.client_args) + list(args)
         else:
             args = ["lightning-cli"] + list(args)
         j = subprocess.run(args, stdout=subprocess.PIPE)

--- a/lndclient.py
+++ b/lndclient.py
@@ -107,7 +107,7 @@ class LndClient:
 
     def _run(self, *args):
         if self.client_args:
-            args = ["lncli", self.client_args] + list(args)
+            args = ["lncli"] + list(self.client_args) + list(args)
         else:
             args = ["lncli"] + list(args)
         j = subprocess.run(args, stdout=subprocess.PIPE)

--- a/suez.py
+++ b/suez.py
@@ -31,7 +31,8 @@ def _since(ts):
     help="Type of LN client.",
 )
 @click.option(
-    "--client-args", default="", help="Extra arguments to pass to client RPC."
+    "--client-args", default=[], multiple=True,
+    help="Extra arguments to pass to client RPC."    
 )
 @click.option(
     "--show-remote-fees", is_flag=True, help="Show (estimate of) remote fees."


### PR DESCRIPTION
Allow using multiple arguments like for LND:

```
poetry run ./suez --client-args=-n=testnet --client-args=--rpcserver=localhost:11009

```
C-lightning:
```
poetry run ./suez --client=c-lightning --client-args=--conf=/home/bitcoin/.lightning/tconfig --client-args=--testnet
```

