### PR TITLE
c-lightning: fix crash when resolved_time missing in forwards

### DIFF
--- a/clnclient.py
+++ b/clnclient.py
@@ -78,7 +78,7 @@ class ClnClient:
         for fe in fwd_events:
             cin = fe["in_channel"]
             cout = fe["out_channel"]
-            ts = int(fe["resolved_time"])
+            ts = int(fe["resolved_time"]) if "resolved_time" in fe else 0
             fee = fe["fee"] // 1000
             amount_in = fe["in_msatoshi"] // 1000
             if cin in self.channels:


### PR DESCRIPTION
`resolved_time` was [added](https://github.com/ElementsProject/lightning/pull/2528) to `listforwards` only in c-lightning v0.7.1. If your node is originally older, even after upgrading you will miss the field for old forwards, which will result in `KeyError`.