### PR TITLE
Problem: "Crashing the Software".

### DIFF
--- a/suez.py
+++ b/suez.py
@@ -26,7 +26,8 @@ def info_box(ln, score):
     grid.add_column()
     grid.add_row("pubkey : ", ln.local_pubkey)
     grid.add_row("alias  : ", ln.local_alias)
-    grid.add_row("score  : ", "{:,}".format(score.get(ln.local_pubkey)))
+    get_score = score.get(ln.local_pubkey)
+    grid.add_row("score  : ", "{:,}".format(get_score if get_score else 0))
     return grid
 
 


### PR DESCRIPTION
# What is the problem?

This issue crashes the software for lack of specific handling if ln.local_pubkey does not have a ```score```, returning None and crashing the "info_box" function at line 29 ```grid.add_row( "score : ", "{:,}".format(score.get(ln.local_pubkey))))``` as we are dealing with format with a ```{:,}``` specification it can't handle and ends up crashing:
```python
info = info_box(ln, score)
  File "/home/admin/suez/suez.py", line 29, in info_box
    grid.add_row("score  : ", "{:,}".format(score.get(ln.local_pubkey)))
TypeError: unsupported format string passed to NoneType.__format
```

# How to solve?
Creating a variable that will get the ```Score``` and when it is added to the grid will do a little ```get_score if get_score else 0``` check this is code:

```python
def info_box(ln, score):
    grid = Table.grid()
    grid.add_column(style="bold")
    grid.add_column()
    grid.add_row("pubkey : ", ln.local_pubkey)
    grid.add_row("alias  : ", ln.local_alias)
    get_score = score.get(ln.local_pubkey)
    grid.add_row("score  : ", "{:,}".format(get_score if get_score else 0))
    return grid
```
This is a very stupid problem, but it can cause problems for users who want to use the tool and don't have a technical background.