### PR TITLE
Add option to exclude specific channel ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Tool for pretty printing and optimizing Lightning Network channels.
 2. `poetry install`
 3. `poetry run ./suez`
 
+## List channels
+
+For example:
+
+`poetry run ./suez --show-scores --show-chan-ids --exclude 788567540478574592`
+
+will list all channels and
+
+* show the [terminal web](https://terminal.lightning.engineering) score of each channel partner
+* show the channel id for each channel
+* exclude the channel with id 788567540478574592 from the list.
+
 ## Channel fee policy
 
 You can set channel fees by passing `--base-fee` and `--fee-rate` parameters.


### PR DESCRIPTION
Adds the possibility to exclude multiple channels from the table.

This can be useful if users don't want to manage specific channels. For example static or private channels that are not used for public routing.
