### PR TITLE
Add forwarding stats option to CLN output parsing

### DIFF
--- a/clnclient.py
+++ b/clnclient.py
@@ -28,8 +28,8 @@ class ClnClient:
                     chan.local_node_id, chan.remote_node_id = self.local_pubkey, p["id"]
                     chan.channel_point = c["channel_id"]
                     chan.uptime, chan.lifetime = None, None
-                    total_msat = int(c["total_msat"].replace("msat", ""))
-                    to_us_msat = int(c["to_us_msat"].replace("msat", ""))
+                    total_msat = int(c["msatoshi_total"])
+                    to_us_msat = int(c["msatoshi_to_us"])
                     chan.capacity, chan.commit_fee = (
                         total_msat // 1000,
                         int(c["last_tx_fee_msat"].replace("msat", "")) // 1000,
@@ -38,6 +38,13 @@ class ClnClient:
                         to_us_msat // 1000,
                         (total_msat - to_us_msat) // 1000,
                     )
+                    chan.ins = c["in_payments_fulfilled"]
+                    chan.ins_percent = chan.outs_percent = 0
+                    if chan.ins > 0:
+                        chan.ins_percent = chan.ins / c["in_payments_offered"]
+                    chan.outs = c["out_payments_fulfilled"]
+                    if chan.outs > 0:
+                        chan.outs_percent = chan.outs / c["out_payments_offered"]
                     if chan.chan_id is not None:
                         info = self._run("listchannels", chan.chan_id)["channels"]
                     else:

--- a/suez.py
+++ b/suez.py
@@ -35,7 +35,7 @@ def info_box(ln, score):
     return grid
 
 
-def channel_table(ln, score, show_remote_fees, show_chan_ids):
+def channel_table(ln, score, show_remote_fees, show_chan_ids, show_forwarding_stats):
     table = Table(box=box.SIMPLE)
     table.add_column("\ninbound", justify="right", style="bright_red")
     table.add_column("\nratio", justify="center")
@@ -47,6 +47,11 @@ def channel_table(ln, score, show_remote_fees, show_chan_ids):
     table.add_column("\nuptime\n(%)", justify="right")
     table.add_column("last\nforward\n(days)", justify="right")
     table.add_column("local\nfees\n(sat)", justify="right", style="bright_cyan")
+    if show_forwarding_stats:
+        table.add_column("\nfwd in", justify="right")
+        table.add_column("\nin %", justify="right")
+        table.add_column("\nfwd out", justify="right")
+        table.add_column("\nout %", justify="right")
     if show_remote_fees:
         table.add_column("remote\nfees\n(sat)", justify="right", style="bright_cyan")
     if score is not None:
@@ -102,6 +107,13 @@ def channel_table(ln, score, show_remote_fees, show_chan_ids):
             _since(c.last_forward) if c.last_forward else "never",
             "{:,}".format(c.local_fees) if c.local_fees else "-",
         ]
+        if show_forwarding_stats:
+            columns += [
+                "{}".format(c.ins),
+                "{:.0%}".format(c.ins_percent),
+                "{}".format(c.outs),
+                "{:.0%}".format(c.outs_percent),
+            ]
         if show_remote_fees:
             columns += [
                 "{:,}".format(c.remote_fees) if c.remote_fees else "-",
@@ -179,6 +191,9 @@ def channel_table(ln, score, show_remote_fees, show_chan_ids):
     "--show-scores", is_flag=True, help="Show node scores (from Lightning Terminal)."
 )
 @click.option("--show-chan-ids", is_flag=True, help="Show channel ids.")
+@click.option(
+    "--show-forwarding-stats", is_flag=True, help="Show forwarding counts and success percentages (CLN)"
+)
 def suez(
     base_fee,
     fee_rate,
@@ -189,6 +204,7 @@ def suez(
     show_remote_fees,
     show_scores,
     show_chan_ids,
+    show_forwarding_stats,
 ):
     clients = {
         "lnd": LndCliClient,
@@ -210,7 +226,7 @@ def suez(
         ln.refresh()
 
     info = info_box(ln, score)
-    table = channel_table(ln, score, show_remote_fees, show_chan_ids)
+    table = channel_table(ln, score, show_remote_fees, show_chan_ids, show_forwarding_stats)
 
     console = Console()
     console.print()


### PR DESCRIPTION
A small change that adds an option --show-forwarding-stats which adds four new columns with numbers of successful incoming and outgoing forwards and corresponding success rates. A very useful metric when considering quality of peering channels.

Only added for CLN support, not sure if the same metric is available under LND/others.