### PR TITLE
fix field naming for CLN 23.05 release and a typo

### DIFF
--- a/clnclient.py
+++ b/clnclient.py
@@ -125,8 +125,14 @@ class ClnClient:
             cin = fe["in_channel"]
             cout = fe["out_channel"]
             ts = int(fe.get("resolved_time", 0))
-            fee = fe["fee"]
-            amount_in = fe["in_msatoshi"] // 1000
+            #
+            # 23.05 naming change renamed everything to _msat
+            if "fee" in fe:
+                fee = fe["fee"]
+                amount_in = fe["in_msatoshi"] // 1000
+            else:
+                fee = fe["fee_msat"]
+                amount_in = fe["in_msat"] // 1000
             if cin in self.channels:
                 self.channels[cin].last_forward = max(
                     ts, self.channels[cin].last_forward

--- a/suez.py
+++ b/suez.py
@@ -177,7 +177,7 @@ def channel_table(
             columns += [
                 f"{c.ins}",
                 f"{c.ins_percent:.0%}",
-                f"{c.outs}"
+                f"{c.outs}",
                 f"{c.outs_percent:.0%}",
             ]
         if show_remote_fees:


### PR DESCRIPTION
Replace some forwarding event field names which were changed in CLN 23.05 release:

fee -> fee_msat
in_msatoshi -> in_msat

Made it backwards compatible with older CLN versions.


Also, fix a typo in forwarding column header definition.